### PR TITLE
Feat/shell completion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -405,6 +405,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.5.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5c5508ea23c5366f77e53f5a0070e5a84e51687ec3ef9e0464c86dc8d13ce98"
+dependencies = [
+ "clap",
+]
+
+[[package]]
+name = "clap_complete_nushell"
+version = "4.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6a8b1593457dfc2fe539002b795710d022dc62a65bf15023f039f9760c7b18a"
+dependencies = [
+ "clap",
+ "clap_complete",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1537,6 +1556,8 @@ dependencies = [
  "arboard",
  "assert_cmd",
  "clap",
+ "clap_complete",
+ "clap_complete_nushell",
  "directories-next",
  "fork",
  "keyring",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,8 @@ keyring = "0.10"
 whoami = "1.1"
 clap = { version = "4.2.2", features = ["derive"]}
 arboard = "3.3.2"
+clap_complete = "4.5.46"
+clap_complete_nushell = "4.5.5"
 
 [target.'cfg(unix)'.dependencies]
 fork = "0.1"

--- a/README.md
+++ b/README.md
@@ -79,16 +79,16 @@ To use hooks, place executable scripts, named after the hook you want to react o
 
 Existing hooks:
 
-* `pre_load` (called before the password database gets loaded)
-* `post_save` (called after the password database is updated)
+- `pre_load` (called before the password database gets loaded)
+- `post_save` (called after the password database is updated)
 
 These commands trigger hooks:
 
-* `page new` (`pre_load`, `post_save` with event name `new_entry`)
-* `page list` (`pre_load` with event name `list_entries`)
-* `page show` (`pre_load` with event name `show_entry`)
-* `page edit` (`pre_load`, `post_save` with event name `edit_entry`)
-* `page remove` (`pre_load`, `post_save` with event name `remove_entry`)
+- `page new` (`pre_load`, `post_save` with event name `new_entry`)
+- `page list` (`pre_load` with event name `list_entries`)
+- `page show` (`pre_load` with event name `show_entry`)
+- `page edit` (`pre_load`, `post_save` with event name `edit_entry`)
+- `page remove` (`pre_load`, `post_save` with event name `remove_entry`)
 
 Example hook scripts can be found [here](https://github.com/deeuu/page/tree/main/example_hooks).
 
@@ -97,6 +97,10 @@ Example hook scripts can be found [here](https://github.com/deeuu/page/tree/main
 If possible, `page` will try to store the passphrase of your database into the OS keyring. You can run `page keyring check` to see if this works. If you no longer want the password to be stored in the keyring run `page keyring forget`.
 
 To skip the keyring integration, `page` takes a global flag `--no-keyring`.
+
+## Shell completion
+
+Shell completion is available via `page completion <SHELL>` where `SHELL` is one of `bash`, `zsh`, `fish`, `elvish`, `powershell`, or `nushell`. Completion scripts are written to standard output.
 
 ## Usage
 
@@ -108,15 +112,16 @@ A password manager with age encryption
 Usage: page [OPTIONS] <COMMAND>
 
 Commands:
-  init     Initialize the password store
-  new      Add a new entry
-  list     List all known entries
-  show     Decrypt and show an entry
-  edit     Edit an entry
-  remove   Remove an entry
-  info     Display status information
-  keyring  Keyring related commands
-  help     Print this message or the help of the given subcommand(s)
+  init        Initialize the password store
+  new         Add a new entry
+  list        List all known entries
+  show        Decrypt and show an entry
+  edit        Edit an entry
+  remove      Remove an entry
+  info        Display status information
+  keyring     Keyring related commands
+  completion  Generate shell completion
+  help        Print this message or the help of the given subcommand(s)
 
 Options:
   -n, --no-keyring  Disable the keyring integration

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,7 +1,7 @@
 use clap::{Parser, Subcommand, ValueEnum};
 
 #[derive(Parser)]
-#[command(bin_name="page", version, about)]
+#[command(bin_name = "page", version, about)]
 pub struct Cli {
     #[command(subcommand)]
     pub cmd: Cmd,
@@ -66,9 +66,7 @@ pub enum Cmd {
         cmd: KeyringCmd,
     },
     /// shell completion
-    Completions {
-        shell: Shell,
-    },
+    Completions { shell: Shell },
 }
 
 #[derive(ValueEnum, Clone)]
@@ -80,7 +78,6 @@ pub enum Shell {
     Powershell,
     Nushell,
 }
-
 
 #[derive(ValueEnum, Clone)]
 pub enum EntryAttribute {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -65,8 +65,8 @@ pub enum Cmd {
         #[command(subcommand)]
         cmd: KeyringCmd,
     },
-    /// shell completion
-    Completions { shell: Shell },
+    /// Generate shell completion
+    Completion { shell: Shell },
 }
 
 #[derive(ValueEnum, Clone)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,7 +1,7 @@
 use clap::{Parser, Subcommand, ValueEnum};
 
 #[derive(Parser)]
-#[command(version, about)]
+#[command(bin_name="page", version, about)]
 pub struct Cli {
     #[command(subcommand)]
     pub cmd: Cmd,
@@ -65,7 +65,22 @@ pub enum Cmd {
         #[command(subcommand)]
         cmd: KeyringCmd,
     },
+    /// shell completion
+    Completions {
+        shell: Shell,
+    },
 }
+
+#[derive(ValueEnum, Clone)]
+pub enum Shell {
+    Bash,
+    Zsh,
+    Fish,
+    Elvish,
+    Powershell,
+    Nushell,
+}
+
 
 #[derive(ValueEnum, Clone)]
 pub enum EntryAttribute {

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,9 +1,13 @@
-use crate::cli::EntryAttribute;
+use crate::cli::{self, EntryAttribute};
 use crate::entries::{load_entries, save_entries, Entry, Storage};
+use clap::CommandFactory;
+use clap_complete::{Shell, generate};
+use clap_complete_nushell::Nushell;
 use crate::hooks::{run_hook, Hook, HookEvent};
 use crate::paths::{entries_file, hooks_dir, storage_dir};
 use crate::utilities;
 use age::secrecy::{ExposeSecret, SecretString};
+use std::io;
 use anyhow::{anyhow, Error, Result};
 use std::fs;
 
@@ -227,3 +231,17 @@ pub fn keyring_forget() -> Result<()> {
     }
     Ok(())
 }
+
+pub fn shell_completion(shell: cli::Shell) {
+    let mut cmd = cli::Cli::command();
+    let bin_name = cmd.get_bin_name().unwrap_or_else(|| cmd.get_name()).to_owned();
+    match shell {
+        cli::Shell::Bash => {generate(Shell::Bash, &mut cmd, bin_name, &mut io::stdout())},
+        cli::Shell::Fish => {generate(Shell::Fish, &mut cmd, bin_name, &mut io::stdout())},
+        cli::Shell::Zsh => {generate(Shell::Zsh, &mut cmd, bin_name, &mut io::stdout())},
+        cli::Shell::Elvish => {generate(Shell::Elvish, &mut cmd, bin_name, &mut io::stdout())},
+        cli::Shell::Powershell => {generate(Shell::PowerShell, &mut cmd, bin_name, &mut io::stdout())},
+        cli::Shell::Nushell => {generate(Nushell, &mut cmd, bin_name, &mut io::stdout())},
+    }
+}
+

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,15 +1,15 @@
 use crate::cli::{self, EntryAttribute};
 use crate::entries::{load_entries, save_entries, Entry, Storage};
-use clap::CommandFactory;
-use clap_complete::{Shell, generate};
-use clap_complete_nushell::Nushell;
 use crate::hooks::{run_hook, Hook, HookEvent};
 use crate::paths::{entries_file, hooks_dir, storage_dir};
 use crate::utilities;
 use age::secrecy::{ExposeSecret, SecretString};
-use std::io;
 use anyhow::{anyhow, Error, Result};
+use clap::CommandFactory;
+use clap_complete::{generate, Shell};
+use clap_complete_nushell::Nushell;
 use std::fs;
+use std::io;
 
 pub fn init(no_keyring: bool) -> Result<(), Error> {
     fs::create_dir_all(storage_dir()?)?;
@@ -234,14 +234,18 @@ pub fn keyring_forget() -> Result<()> {
 
 pub fn shell_completion(shell: cli::Shell) {
     let mut cmd = cli::Cli::command();
-    let bin_name = cmd.get_bin_name().unwrap_or_else(|| cmd.get_name()).to_owned();
+    let bin_name = cmd
+        .get_bin_name()
+        .unwrap_or_else(|| cmd.get_name())
+        .to_owned();
     match shell {
-        cli::Shell::Bash => {generate(Shell::Bash, &mut cmd, bin_name, &mut io::stdout())},
-        cli::Shell::Fish => {generate(Shell::Fish, &mut cmd, bin_name, &mut io::stdout())},
-        cli::Shell::Zsh => {generate(Shell::Zsh, &mut cmd, bin_name, &mut io::stdout())},
-        cli::Shell::Elvish => {generate(Shell::Elvish, &mut cmd, bin_name, &mut io::stdout())},
-        cli::Shell::Powershell => {generate(Shell::PowerShell, &mut cmd, bin_name, &mut io::stdout())},
-        cli::Shell::Nushell => {generate(Nushell, &mut cmd, bin_name, &mut io::stdout())},
+        cli::Shell::Bash => generate(Shell::Bash, &mut cmd, bin_name, &mut io::stdout()),
+        cli::Shell::Fish => generate(Shell::Fish, &mut cmd, bin_name, &mut io::stdout()),
+        cli::Shell::Zsh => generate(Shell::Zsh, &mut cmd, bin_name, &mut io::stdout()),
+        cli::Shell::Elvish => generate(Shell::Elvish, &mut cmd, bin_name, &mut io::stdout()),
+        cli::Shell::Powershell => {
+            generate(Shell::PowerShell, &mut cmd, bin_name, &mut io::stdout())
+        }
+        cli::Shell::Nushell => generate(Nushell, &mut cmd, bin_name, &mut io::stdout()),
     }
 }
-

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,8 +45,9 @@ fn main() -> Result<()> {
             KeyringCmd::Forget => commands::keyring_forget(),
         },
 
-        Cmd::Completions { shell } => { commands::shell_completion(shell); Ok(()) }
-
-
+        Cmd::Completions { shell } => {
+            commands::shell_completion(shell);
+            Ok(())
+        }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,7 +45,7 @@ fn main() -> Result<()> {
             KeyringCmd::Forget => commands::keyring_forget(),
         },
 
-        Cmd::Completions { shell } => {
+        Cmd::Completion { shell } => {
             commands::shell_completion(shell);
             Ok(())
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,5 +44,9 @@ fn main() -> Result<()> {
             KeyringCmd::Check => commands::keyring_check(),
             KeyringCmd::Forget => commands::keyring_forget(),
         },
+
+        Cmd::Completions { shell } => { commands::shell_completion(shell); Ok(()) }
+
+
     }
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -594,3 +594,37 @@ fn fail_remove_no_entry() {
         .stdout(enter_passphrase_show(""))
         .stderr("Error: entry 'no-entry' not found\n");
 }
+
+#[test]
+fn shell_completion_help() {
+    page()
+        .arg("completion")
+        .arg("-h")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "bash, zsh, fish, elvish, powershell, nushell",
+        ));
+}
+
+#[test]
+fn shell_completion_stdout() {
+    page()
+        .arg("completion")
+        .arg("bash")
+        .assert()
+        .success()
+        .stdout(predicate::str::starts_with("_page()"));
+}
+
+#[test]
+fn shell_completion_invalid_shell() {
+    page()
+        .arg("completion")
+        .arg("invalid_shell")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "error: invalid value 'invalid_shell' for '<SHELL>'",
+        ));
+}


### PR DESCRIPTION
Adds shell completion for the CLI, via [clap_complete](https://docs.rs/clap_complete/latest/clap_complete/) and [clap_complete_nushell](https://docs.rs/clap_complete_nushell/latest/clap_complete_nushell/) (for `nusehll`).